### PR TITLE
Add build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+root=$(cd "$(dirname $0)/" && pwd)
+oapi_version=$1
+
+if [ -z "$oapi_version" ]; then
+    echo "please set new oapi version as argument. e.g. \"1.27.0\"" 1>&2
+    exit 1
+fi
+
+oapi_yaml_url="https://raw.githubusercontent.com/outscale/osc-api/${oapi_version}/outscale.yaml"
+curl --silent -o "$root/outscale-ori.yaml" "$oapi_yaml_url"
+
+mv "$root/outscale.yaml" "/tmp/outscale.yaml"
+$root/hacks/patch.rb "$root/outscale-ori.yaml" "$root/old-outscale.yaml" > "$root/outscale.yaml"
+$root/hacks/patch-nooneof.rb "$root/outscale-ori.yaml" > "$root/outscale-java.yaml"
+mv "/tmp/outscale.yaml" "$root/old-outscale.yaml"
+
+
+rm "$root/outscale-ori.yaml"


### PR DESCRIPTION
`build.sh` takes new osc-api version as parameter and generate patched version of outscale API with no oneOf. Two versions are created:
- outscale.yaml: meant for osc-sdk-js, osc-sdk-java, osc-sdk-go, osc-sdk-rust
- outscale-java.yaml: meant for osc-sdk-java

old version of yaml is kept as a reference for future releases.